### PR TITLE
chore(cargo): update repository URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 keywords = ["localization", "internalization", "translation"]
-repository = "https://github.com/eminfedar/simple-translation-rs"
+repository = "https://github.com/eminfedar/simple-localization-rs"
 readme = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The metadata in `Cargo.toml` was pointing out to an unexisting repository. This PR simply updates the repository URL and fixes that.
